### PR TITLE
Support multiple keys and keys from other projects

### DIFF
--- a/DATA_collector/src/data.py
+++ b/DATA_collector/src/data.py
@@ -562,7 +562,7 @@ def run_DATA():
             access_key = validate_params.validate_google_access_key(cwd, project)
 
             # Access BigQuery
-            os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = access_key[0]
+            os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = access_key
             bq = Client(project=project)
 
             # Init SchemaFuncs class


### PR DESCRIPTION
Current code fails when provided a google cloud key JSON file that has valid permissions but was originally created for a different project. This PR uses the google auth API to check before determining that a key is invalid, without disturbing current behaviour for other valid keys. It also checks every json key in the /acces_key/ directory in alphabetical order, and returns the first working key.